### PR TITLE
Fix Shannon key derivation

### DIFF
--- a/main/src/api/ApConnection.cpp
+++ b/main/src/api/ApConnection.cpp
@@ -143,7 +143,7 @@ bell::Result<> ApConnection::solveHelloChallenge(const uint8_t* helloPacket,
             shanSendKey.begin());
 
   // Shan recv key = [0x34:0x54]
-  std::copy(challengeResult.begin() + 0x14, challengeResult.begin() + 0x34,
+  std::copy(challengeResult.begin() + 0x34, challengeResult.begin() + 0x54,
             shanRecvKey.begin());
 
   // Reuse the challengeData buffer for the response


### PR DESCRIPTION
## Summary
- derive Shannon receive key from correct section of handshake data

## Testing
- `cmake --preset tests` *(fails: Could not find Catch2)*
- `cmake --build --preset tests` *(fails: protobuf generator runtime error)*

------
https://chatgpt.com/codex/tasks/task_e_683f3cc5512c832ba86a17fd6dbe10f1