### PR TITLE
Modernize LED status for ESP-IDF v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ authBlob.json
 config.json
 cspot/protos
 targets/esp32/sdkconfig.cspot-wrover-b
+esp-idf/
 *.bak

--- a/targets/esp32/CMakeLists.txt
+++ b/targets/esp32/CMakeLists.txt
@@ -5,7 +5,6 @@ cmake_minimum_required(VERSION 3.5)
 # Don't override EXTRA_COMPONENT_DIRS as platformio uses it.  Instead we append
 # see https://github.com/platformio/platform-espressif32/issues/341
 list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
-list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/led_strip)
 
 if(NOT IDF_NO_INCLUDE)
     include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/targets/esp32/main/CMakeLists.txt
+++ b/targets/esp32/main/CMakeLists.txt
@@ -7,6 +7,7 @@ file(GLOB SOURCES "*.cpp" "*.c")
 idf_component_register(
     SRCS ${SOURCES}
     INCLUDE_DIRS "."
+    REQUIRES led_strip
 )
 idf_build_set_property(COMPILE_OPTIONS "-fdiagnostics-color=always" APPEND)
 

--- a/targets/esp32/main/ESPStatusLed.cpp
+++ b/targets/esp32/main/ESPStatusLed.cpp
@@ -43,8 +43,16 @@ ESPStatusLed::ESPStatusLed() {
 
 #ifdef CONFIG_CSPOT_STATUS_LED_TYPE_RMT
     ESP_LOGI(TAG, "Enabling status LED in RGB mode");
-    pStrip_a = led_strip_init(CONFIG_CSPOT_STATUS_LED_RMT_CHANNEL, CSPOT_STATUS_LED_GPIO, 1);
-    pStrip_a->clear(pStrip_a, 50);
+    led_strip_config_t strip_config = {
+        .strip_gpio_num = CSPOT_STATUS_LED_GPIO,
+        .max_leds = 1,
+    };
+    led_strip_rmt_config_t rmt_config = {
+        .resolution_hz = 10 * 1000 * 1000,
+        .flags.with_dma = false,
+    };
+    ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &strip));
+    led_strip_clear(strip);
 #endif
 
 #if defined(CONFIG_CSPOT_STATUS_LED_TYPE_GPIO) || defined(CONFIG_CSPOT_STATUS_LED_TYPE_RMT)
@@ -58,8 +66,9 @@ ESPStatusLed::ESPStatusLed() {
             #endif
             #ifdef CONFIG_CSPOT_STATUS_LED_TYPE_RMT
             uint32_t color = StatusLedBlinkTimings[(int)self->status][2];
-            self->pStrip_a->set_pixel(self->pStrip_a, 0, (color >> 16) & 0xff, (color >> 8) & 0xff, color & 0xff);
-            self->pStrip_a->refresh(self->pStrip_a, 100);
+            led_strip_set_pixel(self->strip, 0, (color >> 16) & 0xff,
+                                (color >> 8) & 0xff, color & 0xff);
+            led_strip_refresh(self->strip);
             #endif
             vTaskDelay(StatusLedBlinkTimings[(int)self->status][0] / portTICK_PERIOD_MS);
 
@@ -68,7 +77,7 @@ ESPStatusLed::ESPStatusLed() {
             gpio_set_level(CSPOT_STATUS_LED_GPIO, 0);
             #endif
             #ifdef CONFIG_CSPOT_STATUS_LED_TYPE_RMT
-            self->pStrip_a->clear(self->pStrip_a, 50);
+            led_strip_clear(self->strip);
             #endif
             vTaskDelay(StatusLedBlinkTimings[(int)self->status][1] / portTICK_PERIOD_MS);
         }

--- a/targets/esp32/main/ESPStatusLed.h
+++ b/targets/esp32/main/ESPStatusLed.h
@@ -29,7 +29,7 @@ public:
 private:
     StatusLed status = IDLE;
 #ifdef CONFIG_CSPOT_STATUS_LED_TYPE_RMT
-    led_strip_t* pStrip_a;
+    led_strip_handle_t strip;
 #endif
 };
 

--- a/targets/esp32/main/idf_component.yml
+++ b/targets/esp32/main/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/led_strip: "^2.4.1"


### PR DESCRIPTION
## Summary
- ignore local esp-idf checkout
- update esp32 build files
- require official `led_strip` component
- refresh ESPStatusLed implementation for new API

## Testing
- `cmake -S . -B build -DCSPOT_TARGET_TESTS=ON` *(fails: could not find external deps)*

------
https://chatgpt.com/codex/tasks/task_e_68445c3c99c8832ba145919cc1bd3023