### PR TITLE
Fix build path and add stub headers

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT CSPOT_DISABLE_TESTS)
     add_subdirectory("../test" ${CMAKE_CURRENT_BINARY_DIR}/test)
 endif()
 
-list(APPEND EXTRA_LIBS esp_websocket_client esp_http_client protobuf-c cjson)
+list(APPEND EXTRA_LIBS esp_websocket_client esp_http_client protobuf-c cjson mbedtls)
 
 
 # Use protobuf-c and cJSON from ESP-IDF

--- a/targets/esp32/main/BellHTTPServer.h
+++ b/targets/esp32/main/BellHTTPServer.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <functional>
+#include <string>
+struct mg_connection;
+namespace bell {
+class BellHTTPServer {
+ public:
+  explicit BellHTTPServer(int) {}
+  using Handler = std::function<std::string(struct mg_connection*)>;
+  void registerGet(const std::string&, Handler) {}
+  void registerPost(const std::string&, Handler) {}
+  std::string makeJsonResponse(const std::string& data) { return data; }
+};
+}

--- a/targets/esp32/main/BellTask.h
+++ b/targets/esp32/main/BellTask.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <functional>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+namespace bell {
+class Task {
+ public:
+  Task(const char* name = "task", uint32_t stack = 4096, UBaseType_t prio = 5, int core = tskNO_AFFINITY)
+      : name_(name), stack_(stack), prio_(prio), core_(core), handle_(nullptr) {}
+  virtual ~Task() { if (handle_) vTaskDelete(handle_); }
+  void startTask() {
+    xTaskCreatePinnedToCore(&Task::taskFunc, name_, stack_ / sizeof(StackType_t), this, prio_, &handle_, core_);
+  }
+ protected:
+  virtual void runTask() = 0;
+ private:
+  static void taskFunc(void* arg) { static_cast<Task*>(arg)->runTask(); }
+  const char* name_; uint32_t stack_; UBaseType_t prio_; int core_; TaskHandle_t handle_;
+};
+}

--- a/targets/esp32/main/BellUtils.h
+++ b/targets/esp32/main/BellUtils.h
@@ -1,0 +1,3 @@
+#pragma once
+#include "freertos/task.h"
+#define BELL_SLEEP_MS(ms) vTaskDelay(pdMS_TO_TICKS(ms))

--- a/targets/esp32/main/CMakeLists.txt
+++ b/targets/esp32/main/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB SOURCES "*.cpp" "*.c")
 idf_component_register(
     SRCS ${SOURCES}
     INCLUDE_DIRS "."
-    REQUIRES led_strip
+    REQUIRES led_strip driver
 )
 idf_build_set_property(COMPILE_OPTIONS "-fdiagnostics-color=always" APPEND)
 
@@ -16,7 +16,7 @@ option(BUILD_SHARED_LIBS OFF)
 option(BUILD_TESTING OFF)
 
 # Import cspot library
-add_subdirectory("../../../cspot" ${CMAKE_CURRENT_BINARY_DIR}/cspot)
+add_subdirectory("../../../main" ${CMAKE_CURRENT_BINARY_DIR}/cspot)
 
 # Configure the target
 target_link_libraries(${COMPONENT_LIB} PUBLIC cspot)

--- a/targets/esp32/main/MDNSService.h
+++ b/targets/esp32/main/MDNSService.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <string>
+#include <map>
+namespace bell {
+class MDNSService {
+ public:
+  static void registerService(const std::string&, const std::string&, const std::string&, const std::string&, unsigned, const std::map<std::string,std::string>&) {}
+};
+}

--- a/targets/esp32/main/main.cpp
+++ b/targets/esp32/main/main.cpp
@@ -1,4 +1,4 @@
-#include <MDNSService.h>
+#include "MDNSService.h"
 #include <arpa/inet.h>
 #include <mbedtls/aes.h>
 #include <stdio.h>
@@ -26,7 +26,6 @@
 #include <SpircHandler.h>
 
 #include <inttypes.h>
-#include "BellTask.h"
 #include "CircularBuffer.h"
 
 #include "BellUtils.h"


### PR DESCRIPTION
## Summary
- fix build path to main sources
- add `mbedtls` to linked components
- include ESP driver in esp32 component
- provide stub headers for missing bell utilities

## Testing
- `idf.py build` *(fails: fatal error: connect.pb.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6844bdb72554832bb71cf906cf198900